### PR TITLE
Update file ignore patterns

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,9 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+.idea

--- a/tests/test-2.spec.ts
+++ b/tests/test-2.spec.ts
@@ -48,13 +48,16 @@ test("finviz home", async ({ page }) => {
   );
 });
 
+export const FINVIZ_SYMBOLS = ["TSLA", "PLTR", "ADBE", "SNOW", "QQQ", "SOXX"];
+export const finvizURL = (symbol: string) => {
+  return `https://finviz.com/quote.ashx?t=${symbol}&p=d`;
+};
 test.describe("finviz symbols", () => {
-  const symbols = ["TSLA", "PLTR", "ADBE", "SNOW", "QQQ", "SOXX"];
-  for (const symbol of symbols) {
+  for (const symbol of FINVIZ_SYMBOLS) {
     test(`finviz ${symbol}`, async ({ page }) => {
       await finvizCapture(
         page,
-        `https://finviz.com/quote.ashx?t=${symbol}&p=d`,
+        finvizURL(symbol),
         `./${testResultPath}/finviz-${symbol}.png`,
         "#chart"
       );

--- a/upload-files.js
+++ b/upload-files.js
@@ -1,48 +1,57 @@
 const { WebClient, LogLevel } = require("@slack/web-api");
-const {createReadStream} = require('fs');
+const { createReadStream } = require("fs");
 // WebClient instantiates a client that can call API methods
 // When using Bolt, you can use either `app.client` or the `client` passed to listeners.
 const client = new WebClient(process.env.SLACK_BOT_TOKEN, {
   // LogLevel can be imported and used to make debugging simpler
-  logLevel: LogLevel.DEBUG
+  logLevel: LogLevel.DEBUG,
 });
 
+const FINVIZ_SYMBOLS = ["TSLA", "PLTR", "ADBE", "SNOW", "QQQ", "SOXX"];
+const finvizURL = (symbol) => {
+  return `https://finviz.com/quote.ashx?t=${symbol}&p=d`;
+};
 // The name of the file you're going to upload
-const folder = './test-results/';
+const folder = "./test-results/";
 // ID of channel that #stock
 const channelId = "C032JKDP3TJ";
 
 const uploadFile = async () => {
-  
   try {
-    const files = getfiles(folder)
+    const files = getfiles(folder);
     const result = await Promise.all[
       files.map(async (fileName) => {
+        const url = getUrlFromFilename(fileName);
         const result = await client.files.upload({
           // channels can be a list of one to many strings
           channels: channelId,
-          initial_comment: `${fileName} :smile:`,
+          initial_comment: `${fileName} :smile: ${url}`,
           // Include your filename in a ReadStream here
-          file: createReadStream(folder + fileName)
+          file: createReadStream(folder + fileName),
         });
         console.log(result);
-      })  
-    ]
-  }
-  catch (error) {
+      })
+    ];
+  } catch (error) {
     console.error(error);
   }
+};
 
-}
-
-
-const getfiles = (folder) =>{
-// get files list in  test-results folder
-  const fs = require('fs');
+const getfiles = (folder) => {
+  // get files list in  test-results folder
+  const fs = require("fs");
   const files = fs.readdirSync(folder);
   console.log(files);
-  return files;  
-}
+  return files;
+};
+
+const getUrlFromFilename = (filename) => {
+  for (let symbol of FINVIZ_SYMBOLS) {
+    if (filename.includes(symbol)) {
+      return finvizURL(symbol);
+    }
+  }
+};
 
 uploadFile();
 // console.log('files:', getfiles('./test-results/'));


### PR DESCRIPTION
This pull request updates the file ignore patterns in the .gitignore file to exclude the following directories and files: /shelf/, /workspace.xml, /httpRequests/, /dataSources/, /dataSources.local.xml, and .idea. Additionally, it removes the trailing newline at the end of the file.